### PR TITLE
修复动态库自定义图片无法找到

### DIFF
--- a/SGQRCode/SGQRCodeScanView.m
+++ b/SGQRCode/SGQRCodeScanView.m
@@ -281,7 +281,11 @@
 - (UIImageView *)scanningline {
     if (!_scanningline) {
         _scanningline = [[UIImageView alloc] init];
-        _scanningline.image = [UIImage SG_imageNamed:self.scanImageName inBundle:[NSBundle bundleForClass:[self class]]];
+        UIImage *imageScanningline=[UIImage SG_imageNamed:self.scanImageName inBundle:[NSBundle bundleForClass:[self class]]];
+        if (!imageScanningline) {
+            imageScanningline=[UIImage imageNamed:self.scanImageName];
+        }
+        _scanningline.image = imageScanningline;
     }
     return _scanningline;
 }


### PR DESCRIPTION
pod设置动态库use_frameworks!时，自定义图片无法找到，直接去pod 的framework下找了没在app目录查询，建议再添加个设置image的方法，如果模块化后一个模块的封装pod依赖这个库到时候图片现在的修改也找不到，设置image能比较好的扩展