### PR TITLE
修复动态库资源获取异常 扩展图片设置

### DIFF
--- a/SGQRCode/SGQRCodeScanView.h
+++ b/SGQRCode/SGQRCodeScanView.h
@@ -34,6 +34,9 @@ typedef enum : NSUInteger {
 @property (nonatomic, assign) ScanAnimationStyle scanAnimationStyle;
 /** 扫描线名 */
 @property (nonatomic, copy) NSString *scanImageName;
+/** 扫描线图片 */
+@property (nonatomic, strong) UIImage *scanImage;
+
 /** 边框颜色，默认白色 */
 @property (nonatomic, strong) UIColor *borderColor;
 /** 边角位置，默认 CornerLoactionDefault */

--- a/SGQRCode/SGQRCodeScanView.m
+++ b/SGQRCode/SGQRCodeScanView.m
@@ -282,13 +282,17 @@
         _scanningline = [[UIImageView alloc] init];
         NSURL *bundleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"SGQRCode" withExtension:@"bundle"];
         NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];
-        UIImage *image = [UIImage imageNamed:self.scanImageName inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage *image = bundle ? [UIImage imageNamed:self.scanImageName inBundle:bundle compatibleWithTraitCollection:nil] : nil;
         if (!image) {
             image = [UIImage imageNamed:self.scanImageName];
         }
         _scanningline.image = image;
     }
     return _scanningline;
+}
+
+- (UIImage *)scanImage{
+    return self.scanningline.image;
 }
 
 #pragma mark - - - set
@@ -298,6 +302,10 @@
 
 - (void)setScanImageName:(NSString *)scanImageName {
     _scanImageName = scanImageName;
+}
+
+- (void)setScanImage:(UIImage *)scanImage{
+    self.scanningline.image = scanImage;
 }
 
 - (void)setBorderColor:(UIColor *)borderColor {

--- a/SGQRCode/SGQRCodeScanView.m
+++ b/SGQRCode/SGQRCodeScanView.m
@@ -280,7 +280,7 @@
 - (UIImageView *)scanningline {
     if (!_scanningline) {
         _scanningline = [[UIImageView alloc] init];
-        NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"SGQRCode" withExtension:@"bundle"];
+        NSURL *bundleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"SGQRCode" withExtension:@"bundle"];
         NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];
         UIImage *image = [UIImage imageNamed:self.scanImageName inBundle:bundle compatibleWithTraitCollection:nil];
         if (!image) {

--- a/SGQRCode/SGQRCodeScanView.m
+++ b/SGQRCode/SGQRCodeScanView.m
@@ -281,7 +281,7 @@
     if (!_scanningline) {
         _scanningline = [[UIImageView alloc] init];
         NSURL *bundleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"SGQRCode" withExtension:@"bundle"];
-        NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];
+        NSBundle *bundle = bundleURL ? [NSBundle bundleWithURL:bundleURL] : nil;
         UIImage *image = bundle ? [UIImage imageNamed:self.scanImageName inBundle:bundle compatibleWithTraitCollection:nil] : nil;
         if (!image) {
             image = [UIImage imageNamed:self.scanImageName];


### PR DESCRIPTION
根据类的所在位置获取bundle，bundle,bundleURL为空时会直接crash

